### PR TITLE
fix: verus playlist title was empty string

### DIFF
--- a/yt_dlp_plugins/extractor/verus.py
+++ b/yt_dlp_plugins/extractor/verus.py
@@ -109,5 +109,5 @@ class VerusIE(InfoExtractor):
         return self.playlist_result(
             entries,
             playlist_id=playlist_id,
-            playlist_title=f""
+            playlist_title=playlist_id
         )


### PR DESCRIPTION
## Summary
- `playlist_title=f""` in `VerusIE._real_extract` was a placeholder that never got filled in
- Replace with `playlist_title=playlist_id`, which uses the hostname from the `verus://hostname/...` URL

## Test plan
- [ ] Import smoke test: `python -c "from yt_dlp_plugins.extractor.verus import VerusIE; print(VerusIE._VALID_URL)"`
- [ ] Live test against a `verus://` URL to confirm the playlist title is no longer blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)